### PR TITLE
Fix comment string

### DIFF
--- a/lib/wercker_bundle_update_pr.rb
+++ b/lib/wercker_bundle_update_pr.rb
@@ -59,6 +59,7 @@ module WerckerBundleUpdatePr
 
     comment = <<-EOC
 #{compare_linker.make_compare_links.to_a.join("\n")}
+
 Powered by [compare_linker](https://rubygems.org/gems/compare_linker)
           EOC
 


### PR DESCRIPTION
Added a newline so that `Powered by ...` text does not follow after the last line of diffs.
